### PR TITLE
- init script path fixed

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,12 +10,12 @@ To use the script, you can either pass arguments directly or enter them interact
 
 ### Direct argument passing
 ```bash
-bash <(curl -s https://raw.githubusercontent.com/blumilksoftware/boilerplate/init.sh) <app-name> [app-namespace] [branch-name] [app-host-port] [db-host-port] [mailpit-dashboard-port] [redis-host-port]
+bash <(curl -s https://raw.githubusercontent.com/blumilksoftware/boilerplate/main/init.sh) <app-name> [app-namespace] [branch-name] [app-host-port] [db-host-port] [mailpit-dashboard-port] [redis-host-port]
 ```
 
 - `<app-name>`: Required. Name of your application.
-- `[app-namespace]`: Optional. The namespace for your application. Defaults to **App** if not provided.
-- `[branch-name]`: Optional. The specific branch to clone. Defaults to the **main** branch if not provided.
+- `[app-namespace]`: Optional. The namespace for your application. Defaults to `App` if not provided.
+- `[branch-name]`: Optional. The specific branch to clone. Defaults to the `main` branch if not provided.
 - `[app-host-port]`: Optional. Docker app host port. Defaults to 63851.
 - `[db-host-port]`: Optional. Docker database host port. Defaults to 63853.
 - `[mailpit-dashboard-port]`: Optional. Docker Mailpit dashboard host port. Defaults to 63854.
@@ -24,6 +24,6 @@ bash <(curl -s https://raw.githubusercontent.com/blumilksoftware/boilerplate/ini
 ### Interactive Mode
 Run the script without arguments:
 ```bash
-bash <(curl -s https://raw.githubusercontent.com/blumilksoftware/boilerplate/init.sh)
+bash <(curl -s https://raw.githubusercontent.com/blumilksoftware/boilerplate/main/init.sh)
 ```
 You will be prompted to enter the application name, namespace, branch name, and Docker port settings.


### PR DESCRIPTION
Current readme is invalid as https://raw.githubusercontent.com/blumilksoftware/boilerplate/init.sh doesn't exist. Look like proper path has branch name in it: https://raw.githubusercontent.com/blumilksoftware/boilerplate/main/init.sh

This PR fixes this invalid path.